### PR TITLE
Update version to 0.1.0

### DIFF
--- a/game.libretro.fsuae/addon.xml.in
+++ b/game.libretro.fsuae/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="game.libretro.fsuae"
 		name="Amiga (FS-UAE)"
-		version="0.0.0"
+		version="0.1.0"
 		provider-name="Libretro">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>


### PR DESCRIPTION
A version equals to 0.0.0 is discarded by Kodi. This update is required to activate game.libretro.fsuae.